### PR TITLE
Add ports info to bsg_14.memgen.json

### DIFF
--- a/gf12/toplevels/bsg_ac_blackparrot_single_core_rc5/scripts/harden/bsg_14.memgen.json
+++ b/gf12/toplevels/bsg_ac_blackparrot_single_core_rc5/scripts/harden/bsg_14.memgen.json
@@ -1,15 +1,15 @@
 { "memories": [
-    {"name": "gf14_1rw_d512_w64_m2_byte",  "width":  64, "depth":  512, "mux": 2, "mask": 8, "banks": 2, "type": "sram" },
-    {"name": "gf14_1rw_d64_w124_m2_bit",   "width": 124, "depth":   64, "mux": 2, "mask": 1, "banks": 1, "type": "rf"   },
-    {"name": "gf14_1rw_d64_w7_m4_bit",     "width":   7, "depth":   64, "mux": 4, "mask": 1, "banks": 1, "type": "rf"   },
-    {"name": "gf14_1rw_d64_w15_m4_bit",    "width":  15, "depth":   64, "mux": 4, "mask": 1, "banks": 1, "type": "rf"   },
+    {"name": "gf14_1rw_d512_w64_m2_byte",  "ports": "1rw", "width":  64, "depth":  512, "mux": 2, "mask": 8, "banks": 2, "type": "sram" },
+    {"name": "gf14_1rw_d64_w124_m2_bit",   "ports": "1rw", "width": 124, "depth":   64, "mux": 2, "mask": 1, "banks": 1, "type": "rf"   },
+    {"name": "gf14_1rw_d64_w7_m4_bit",     "ports": "1rw", "width":   7, "depth":   64, "mux": 4, "mask": 1, "banks": 1, "type": "rf"   },
+    {"name": "gf14_1rw_d64_w15_m4_bit",    "ports": "1rw", "width":  15, "depth":   64, "mux": 4, "mask": 1, "banks": 1, "type": "rf"   },
 
-    {"name": "gf14_1r1w_d32_w64_m1",       "width":  64, "depth":   32, "mux": 1, "mask": 0, "banks": 2, "type": "2rf"  },
-    {"name": "gf14_1r1w_d32_w66_m1",       "width":  66, "depth":   32, "mux": 1, "mask": 0, "banks": 2, "type": "2rf"  },
-    {"name": "gf14_1r1w_d64_w50_m2",       "width":  50, "depth":   64, "mux": 2, "mask": 0, "banks": 2, "type": "2rf"  },
+    {"name": "gf14_1r1w_d32_w64_m1",       "ports": "1r1w", "width":  64, "depth":   32, "mux": 1, "mask": 0, "banks": 2, "type": "2rf"  },
+    {"name": "gf14_1r1w_d32_w66_m1",       "ports": "1r1w", "width":  66, "depth":   32, "mux": 1, "mask": 0, "banks": 2, "type": "2rf"  },
+    {"name": "gf14_1r1w_d64_w50_m2",       "ports": "1r1w", "width":  50, "depth":   64, "mux": 2, "mask": 0, "banks": 2, "type": "2rf"  },
 
-    {"name": "gf14_1rw_d128_w116_m2_bit",  "width": 116, "depth":  128, "mux": 2, "mask": 1, "banks": 1, "type": "rf"   },
-    {"name": "gf14_1rw_d128_w15_m4_bit",   "width":  15, "depth":  128, "mux": 4, "mask": 1, "banks": 1, "type": "rf"   }
+    {"name": "gf14_1rw_d128_w116_m2_bit",  "ports": "1rw", "width": 116, "depth":  128, "mux": 2, "mask": 1, "banks": 1, "type": "rf"   },
+    {"name": "gf14_1rw_d128_w15_m4_bit",   "ports": "1rw", "width":  15, "depth":  128, "mux": 4, "mask": 1, "banks": 1, "type": "rf"   }
   ],
   "dont_compile": [
   ]


### PR DESCRIPTION
This PR adds missing ports info to the bsg_14.memgen.json file in bsg_ac_blackparrot_single_core_rc5.